### PR TITLE
Small Wither targeting

### DIFF
--- a/src/main/java/com/kashdeya/trolloresreborn/handlers/TOREventHandler.java
+++ b/src/main/java/com/kashdeya/trolloresreborn/handlers/TOREventHandler.java
@@ -102,7 +102,8 @@ public class TOREventHandler {
 					wither.setPosition(pos.getX() + 0.5D, pos.getY() + 0.5D, pos.getZ() + 0.5D);
 					event.getWorld().spawnEntity(wither);
 					wither.onInitialSpawn(event.getWorld().getDifficultyForLocation(wither.getPosition()), (IEntityLivingData) null);
-					wither.setAttackTarget(event.getHarvester());
+					if(!(event.getHarvester() instanceof FakePlayer))
+						wither.setAttackTarget(event.getHarvester());
 	        	}
 			}
 		}

--- a/src/main/java/com/kashdeya/trolloresreborn/handlers/TOREventHandler.java
+++ b/src/main/java/com/kashdeya/trolloresreborn/handlers/TOREventHandler.java
@@ -102,6 +102,7 @@ public class TOREventHandler {
 					wither.setPosition(pos.getX() + 0.5D, pos.getY() + 0.5D, pos.getZ() + 0.5D);
 					event.getWorld().spawnEntity(wither);
 					wither.onInitialSpawn(event.getWorld().getDifficultyForLocation(wither.getPosition()), (IEntityLivingData) null);
+					wither.setAttackTarget(event.getHarvester());
 	        	}
 			}
 		}


### PR DESCRIPTION
Setting the player who mined the block as the target should make the small wither aggro them directly, instead of going around, doing their own thing.